### PR TITLE
Adds ability to change the default date format used when importing

### DIFF
--- a/WTAData/categories/NSManagedObject+WTADataImport.h
+++ b/WTAData/categories/NSManagedObject+WTADataImport.h
@@ -77,3 +77,20 @@
                                context:(NSManagedObjectContext *)context;
 
 @end
+
+@interface NSDateFormatter (WTADataImport)
+
+/**
+ Default date format to use when import date objects.
+ 
+ If no date format is defined in the user info of the entity then this format will be use.
+ Defaults to @"yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+ */
++ (NSString *)defaultImportDateFormat;
+
+/**
+ Sets defaultImportDateFormat - defaults to @"yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+ */
++ (void)setDefaultImportDateFormat:(NSString *)defaultImportDateFormat;
+
+@end

--- a/WTADataExample/WTADataExampleTests/WTADataExampleTests.m
+++ b/WTADataExample/WTADataExampleTests/WTADataExampleTests.m
@@ -149,40 +149,6 @@
     }];
 }
 
-- (void)testDateFormatImport
-{
-    NSDate *now = [NSDate date];
-    
-    NSDateFormatter *ISO8601DateFormater = [NSDateFormatter new];
-    [ISO8601DateFormater setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
-    
-    NSDateFormatter *customFormatter = [NSDateFormatter new];
-    [customFormatter setDateFormat:@"M/d/yyyy"];
-    
-    NSDictionary *dictionary = @{
-                                 @"epochDateAttribute" : @([now timeIntervalSince1970]),
-                                 @"dateAttribute" : [ISO8601DateFormater stringFromDate:now],
-                                 @"customDateAttribute" : [customFormatter stringFromDate:now]
-                                 };
-    
-    NSManagedObjectContext *context = [[self wtaData] mainContext];
-    Entity *entity = [Entity importEntityFromObject:dictionary context:context];
-    
-    NSCalendar *calendar = [NSCalendar currentCalendar];
-    
-    XCTAssert([calendar compareDate:[entity dateAttribute]
-                             toDate:now
-                  toUnitGranularity:NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitYear] == NSOrderedSame);
-    
-    XCTAssert([calendar compareDate:[entity customDateAttribute]
-                             toDate:now
-                  toUnitGranularity:NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitYear] == NSOrderedSame);
-    
-    XCTAssert([calendar compareDate:[entity epochDateAttribute]
-                             toDate:now
-                  toUnitGranularity:NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitYear] == NSOrderedSame);
-}
-
 - (void)testSaveInBackgroundAndWait
 {
     NSString *const initialStringValue = @"TestSaveInBackgroundAndWait";


### PR DESCRIPTION
Current behavior defaults to using "yyyy-MM-dd'T'HH:mm:ssZZZZZ" for importing dates if no custom date format was given for the entity. This pull request adds the ability to define this default format string yourself.