### PR TITLE
feature/NSManagedObject_inContext

### DIFF
--- a/WTAData.podspec
+++ b/WTAData.podspec
@@ -17,5 +17,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/willowtreeapps/WTAData.git", :tag => s.version }
   s.source_files  = "WTAData", "WTAData/**/*.{h,m}"
   s.exclude_files = "Classes/Exclude"
+  s.requires_arc = true
 
 end

--- a/WTAData.podspec
+++ b/WTAData.podspec
@@ -1,11 +1,21 @@
 Pod::Spec.new do |s|
+
   s.name         = "WTAData"
-  s.version      = "1.2.0"
+  s.version      = "1.2.1"
   s.summary      = "WTAData is a wrapper for CoreData to handle commmon operations associated with managing a CoreData stack"
-  s.license      = "Proprietary"
-  s.author       = { "WillowTree, Inc." => "willowtreeapps.com" }
+
+  s.description  = <<-DESC
+                  WTAData provides a light-weight interface for setting up an asynchronous CoreData stack. WTAData utilizes two NSManagedObjectContexts: main and background, for achieving fast and performant core data access. The main context is generally used for read access to the core data stack. The main context updates automatically when changes are saved by the background managed object context. The background context is primarily used for performing saves in background threads, such as when a network call completes. 
+                   DESC
+
+  s.homepage     = "https://github.com/willowtreeapps/WTAData"
+
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+
+  s.author             = { "WillowTree, Inc." => "willowtreeapps.com" } 
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/willowtreeapps/WTAData.git", :tag => s.version }
   s.source_files  = "WTAData", "WTAData/**/*.{h,m}"
   s.exclude_files = "Classes/Exclude"
+
 end

--- a/WTAData/categories/NSManagedObject+WTAData.h
+++ b/WTAData/categories/NSManagedObject+WTAData.h
@@ -76,7 +76,7 @@
  
  @param otherContext the context the returned NSManagedObject instance will be contained in, or nil if it doesn't exit or there was an error.
   */
-- (instancetype)inContext:(NSManagedObjectContext *)otherContext;
+- (instancetype)inContext:(NSManagedObjectContext *)otherContext error:(NSError**)error;
 
 /**
  Creates a NSAsynchronousFetchRequests with the specified predicate, sort descriptor, and completion

--- a/WTAData/categories/NSManagedObject+WTAData.h
+++ b/WTAData/categories/NSManagedObject+WTAData.h
@@ -93,6 +93,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)inContext:(NSManagedObjectContext *)otherContext error:(NSError**)error;
 
 /**
+ Returns count of entities of a given type in a NSManagedObjectContext.
+  */
++ (NSUInteger)countWithContext:(NSManagedObjectContext *)context error:(NSError**)error;
+
+/**
+ Returns count of entities of a given, in a NSManagedObjectContext, that pass a speified searchFilter.
+ */
++ (NSUInteger)countOfEntitiesWithPredicate:(NSPredicate *)searchFilter inContext:(NSManagedObjectContext *)context  error:(NSError**)error;
+
+/**
  Creates a NSAsynchronousFetchRequests with the specified predicate, sort descriptor, and completion
  block.
  

--- a/WTAData/categories/NSManagedObject+WTAData.h
+++ b/WTAData/categories/NSManagedObject+WTAData.h
@@ -72,6 +72,13 @@
 + (void)deleteAllInContext:(NSManagedObjectContext *)context predicate:(NSPredicate *)predicate;
 
 /**
+ Returns another NSManagedObject instance that is within a different NSManagedObjectContext.
+ 
+ @param otherContext the context the returned NSManagedObject instance will be contained in, or nil if it doesn't exit or there was an error.
+  */
+- (instancetype)inContext:(NSManagedObjectContext *)otherContext;
+
+/**
  Creates a NSAsynchronousFetchRequests with the specified predicate, sort descriptor, and completion
  block.
  

--- a/WTAData/categories/NSManagedObject+WTAData.m
+++ b/WTAData/categories/NSManagedObject+WTAData.m
@@ -58,19 +58,20 @@
     return [NSEntityDescription insertNewObjectForEntityForName:[self entityName] inManagedObjectContext:context];
 }
 
-- (instancetype)inContext:(NSManagedObjectContext *)otherContext
+- (instancetype)inContext:(NSManagedObjectContext *)otherContext error:(NSError**)error
 {
-    NSError *error = nil;
     if ([self.objectID isTemporaryID])
     {
-        if ([self.managedObjectContext obtainPermanentIDsForObjects:@[self] error:&error])
-        {
+        BOOL success = [[self managedObjectContext] obtainPermanentIDsForObjects:@[self] error:error];
+        if (!success) {
+            return nil;
+        }
+        if (error) {
             return nil;
         }
     }
     
-    error = nil;
-    NSManagedObject *selfInOtherContext = [otherContext existingObjectWithID:self.objectID error:&error];
+    NSManagedObject *selfInOtherContext = [otherContext existingObjectWithID:self.objectID error:error];
     return selfInOtherContext;
 }
 

--- a/WTAData/categories/NSManagedObject+WTAData.m
+++ b/WTAData/categories/NSManagedObject+WTAData.m
@@ -43,8 +43,6 @@
     }
 }
 
-
-
 + (NSEntityDescription *)entityDescriptionInContext:(NSManagedObjectContext *)context
 {
     return [NSEntityDescription entityForName:[self entityName] inManagedObjectContext:context];
@@ -60,6 +58,21 @@
     return [NSEntityDescription insertNewObjectForEntityForName:[self entityName] inManagedObjectContext:context];
 }
 
+- (instancetype)inContext:(NSManagedObjectContext *)otherContext
+{
+    NSError *error = nil;
+    if ([self.objectID isTemporaryID])
+    {
+        if ([self.managedObjectContext obtainPermanentIDsForObjects:@[self] error:&error])
+        {
+            return nil;
+        }
+    }
+    
+    error = nil;
+    NSManagedObject *selfInOtherContext = [otherContext existingObjectWithID:self.objectID error:&error];
+    return selfInOtherContext;
+}
 
 + (NSAsynchronousFetchRequest *)asyncFetchRequestWithPredicate:(NSPredicate *)predicate sortDescriptors:(NSArray *)sortDescriptors completion:(NSPersistentStoreAsynchronousFetchResultCompletionBlock)completion
 {

--- a/WTAData/categories/NSManagedObject+WTAData.m
+++ b/WTAData/categories/NSManagedObject+WTAData.m
@@ -75,6 +75,20 @@
     return selfInOtherContext;
 }
 
++ (NSUInteger)countWithContext:(NSManagedObjectContext *)context error:(NSError**)error
+{
+    return [self countOfEntitiesWithPredicate:nil inContext:context error:error];
+}
+
++ (NSUInteger)countOfEntitiesWithPredicate:(NSPredicate *)searchFilter
+                                 inContext:(NSManagedObjectContext *)context
+                                     error:(NSError**)error
+{
+    NSFetchRequest* request = [self fetchRequestWithPredicate:searchFilter];
+    NSUInteger count = [context countForFetchRequest:request error:error];
+    return count;
+}
+
 + (NSAsynchronousFetchRequest *)asyncFetchRequestWithPredicate:(NSPredicate *)predicate sortDescriptors:(NSArray *)sortDescriptors completion:(NSPersistentStoreAsynchronousFetchResultCompletionBlock)completion
 {
     NSFetchRequest *request = [self fetchRequestWithPredicate:predicate sortDescriptors:sortDescriptors];

--- a/WTADataExample/WTADataExampleTests/WTADataExampleTests.m
+++ b/WTADataExample/WTADataExampleTests/WTADataExampleTests.m
@@ -248,4 +248,30 @@
 }
 
 
+- (void)testInContext
+{
+    NSString *const initialStringValue = @"TestSaveInBackgroundAndUseInContext";
+    
+    __weak typeof(self) weakSelf = self;
+    __block Entity *entity;
+    [weakSelf.wtaData saveInBackgroundAndWait:^(NSManagedObjectContext *context) {
+        //Given
+        entity = [NSEntityDescription insertNewObjectForEntityForName:[[Entity class] description]
+                                               inManagedObjectContext:context];
+        entity.stringAttribute = initialStringValue;
+    } error:nil];
+    
+    //When
+    
+    // replacing this code (and adding extra error checking) with the following code
+    //Entity *mainThreadEntity = (Entity *)[self.wtaData.mainContext existingObjectWithID:entity.objectID error:nil];
+    NSError* error;
+    Entity* mainThreadEntity = [entity inContext:self.wtaData.mainContext error:&error];
+    
+    //Then
+    XCTAssertNil(error);
+    XCTAssertNotNil(mainThreadEntity);
+    XCTAssertEqualObjects(mainThreadEntity.stringAttribute, initialStringValue);
+}
+
 @end


### PR DESCRIPTION
Simple implementation of a NSManagedObject helper method inContext that returns a copy of this object in a new context. 

If object is temporary (isTemporaryID) will call obtainPermanentIDsForObjects first. Otherwise uses existingObjectWithID to get an object with same objectID in a new context.