### PR TITLE
Bugfix/fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: objective-c
+osx_image: xcode7.1
 xcode_project: WTADataExample/WTADataExample.xcodeproj
 xcode_scheme: WTADataExample
-xcode_sdk: iphonesimulator
+xcode_sdk: iphonesimulator9.1
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 xcode_project: WTADataExample/WTADataExample.xcodeproj
 xcode_scheme: WTADataExample
-xcode_sdk: iphonesimulator8.1
+xcode_sdk: iphonesimulator9.0
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 xcode_project: WTADataExample/WTADataExample.xcodeproj
 xcode_scheme: WTADataExample
-xcode_sdk: iphonesimulator9.0
+xcode_sdk: iphonesimulator
 notifications:
   email: false

--- a/WTAData.podspec
+++ b/WTAData.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "WTAData"
-  s.version      = "1.4.0"
+  s.version      = "1.4.1"
   s.summary      = "WTAData is a wrapper for CoreData to handle commmon operations associated with managing a CoreData stack"
 
   s.description  = <<-DESC

--- a/WTAData/WTAData.m
+++ b/WTAData/WTAData.m
@@ -40,6 +40,17 @@
 @end
 
 @implementation WTAData
+- (instancetype)init
+{
+    NSString* dataModelPath = [[NSBundle mainBundle] pathForResource:nil ofType:@"momd"];
+    if (!dataModelPath)
+    {
+        dataModelPath = [[NSBundle mainBundle] pathForResource:nil ofType:@"mom"];
+    }
+    
+    NSString* modelName = [[dataModelPath stringByDeletingPathExtension] lastPathComponent];
+    return [self initWithModelNamed:modelName];
+}
 
 - (instancetype)initWithModelNamed:(NSString *)modelName
 {

--- a/WTAData/categories/NSManagedObjectContext+WTAData.m
+++ b/WTAData/categories/NSManagedObjectContext+WTAData.m
@@ -34,30 +34,38 @@
 - (BOOL)saveContext:(NSError **)error
 {
     __block BOOL hasChanges = NO;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
     if ([self concurrencyType] == NSConfinementConcurrencyType)
     {
         hasChanges = [self hasChanges];
     }
     else
     {
+#endif
         [self performBlockAndWait:^{
             hasChanges = [self hasChanges];
         }];
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
     }
+#endif
     
     __block BOOL saveResult = NO;
     @try
     {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
         if ([self concurrencyType] == NSConfinementConcurrencyType)
         {
             saveResult = [self save:nil];
         }
         else
         {
+#endif
             [self performBlockAndWait:^{
                 saveResult = [self save:error];
             }];
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0
         }
+#endif
     }
     @catch(NSException *exception)
     {

--- a/WTADataExample/WTADataExample.xcodeproj/project.pbxproj
+++ b/WTADataExample/WTADataExample.xcodeproj/project.pbxproj
@@ -262,7 +262,7 @@
 		03F474251A013506003A7A86 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "WillowTree, Inc.";
 				TargetAttributes = {
 					03F4742C1A013506003A7A86 = {
@@ -399,6 +399,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -413,7 +414,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -448,7 +449,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -461,6 +462,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = WTADataExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -471,6 +473,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = WTADataExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -479,16 +482,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = WTADataExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/WTADataExample.app/WTADataExample";
 			};
@@ -498,12 +499,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = WTADataExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/WTADataExample.app/WTADataExample";
 			};

--- a/WTADataExample/WTADataExample.xcodeproj/xcshareddata/xcschemes/WTADataExample.xcscheme
+++ b/WTADataExample/WTADataExample.xcodeproj/xcshareddata/xcschemes/WTADataExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:WTADataExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -82,14 +85,20 @@
             ReferencedContainer = "container:WTADataExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/WTADataExample/WTADataExample/Info.plist
+++ b/WTADataExample/WTADataExample/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/WTADataExample/WTADataExampleTests/Info.plist
+++ b/WTADataExample/WTADataExampleTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Add conditional compilation around save code that uses
NSConfinementConcurrencyType, since that is deprecated on iOS 9 but
still needed if we're targetting an earlier OS. This silences the
warnings without sacrificing compatibility.

Also, add an override for -init since it is now marked as a designated
initializer on NSObject.

And fix a spurious Framework search path in the Tests target.