### PR TITLE
Fix entity name inferring for Swift classes

### DIFF
--- a/WTAData/categories/NSManagedObject+WTAData.m
+++ b/WTAData/categories/NSManagedObject+WTAData.m
@@ -50,7 +50,18 @@
 
 + (NSString *)entityName
 {
-    return NSStringFromClass([self class]);
+    // NSStringFromClass returns the full module name for swift classes (e.g. WTAData.SwiftEntity),
+    // but this does not match the name of the entity as we would typically name them in the model
+    // (i.e. SwiftEntity). This code attempts to return the properly guessed entity name as a
+    // default
+    NSString *entityName = NSStringFromClass([self class]);
+    NSArray *components = [entityName componentsSeparatedByString:@"."];
+    
+    if (components.count > 1) {
+        return components.lastObject;
+    } else {
+        return entityName;
+    }
 }
 
 + (instancetype)createEntityInContext:(NSManagedObjectContext *)context

--- a/WTADataExample/WTADataExample-Bridging-Header.h
+++ b/WTADataExample/WTADataExample-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/WTADataExample/WTADataExample.xcodeproj/project.pbxproj
+++ b/WTADataExample/WTADataExample.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		036F93931C5BC59F0021D692 /* SwiftEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036F93911C5BC59F0021D692 /* SwiftEntity+CoreDataProperties.swift */; };
+		036F93941C5BC59F0021D692 /* SwiftEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036F93911C5BC59F0021D692 /* SwiftEntity+CoreDataProperties.swift */; };
+		036F93951C5BC59F0021D692 /* SwiftEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036F93921C5BC59F0021D692 /* SwiftEntity.swift */; };
+		036F93961C5BC59F0021D692 /* SwiftEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036F93921C5BC59F0021D692 /* SwiftEntity.swift */; };
+		036F93981C5BC6B00021D692 /* WTADataSwiftIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036F93971C5BC6B00021D692 /* WTADataSwiftIntegrationTests.swift */; };
 		038D586E1B823C180007D15B /* Entity.m in Sources */ = {isa = PBXBuildFile; fileRef = 038D58621B823C180007D15B /* Entity.m */; };
 		038D586F1B823C180007D15B /* _Entity.m in Sources */ = {isa = PBXBuildFile; fileRef = 038D58651B823C180007D15B /* _Entity.m */; };
 		038D58701B823C180007D15B /* _PrimaryKeyEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = 038D58671B823C180007D15B /* _PrimaryKeyEntity.m */; };
@@ -44,6 +49,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		036F938E1C5BC42F0021D692 /* WTADataExample 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WTADataExample 2.xcdatamodel"; sourceTree = "<group>"; };
+		036F938F1C5BC59E0021D692 /* WTADataExample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WTADataExample-Bridging-Header.h"; sourceTree = "<group>"; };
+		036F93901C5BC59E0021D692 /* WTADataExampleTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WTADataExampleTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		036F93911C5BC59F0021D692 /* SwiftEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		036F93921C5BC59F0021D692 /* SwiftEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftEntity.swift; sourceTree = "<group>"; };
+		036F93971C5BC6B00021D692 /* WTADataSwiftIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WTADataSwiftIntegrationTests.swift; sourceTree = "<group>"; };
 		038D58611B823C180007D15B /* Entity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Entity.h; sourceTree = "<group>"; };
 		038D58621B823C180007D15B /* Entity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Entity.m; sourceTree = "<group>"; };
 		038D58641B823C180007D15B /* _Entity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _Entity.h; sourceTree = "<group>"; };
@@ -109,6 +120,8 @@
 		038D58601B823C180007D15B /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				036F93911C5BC59F0021D692 /* SwiftEntity+CoreDataProperties.swift */,
+				036F93921C5BC59F0021D692 /* SwiftEntity.swift */,
 				038D58611B823C180007D15B /* Entity.h */,
 				038D58621B823C180007D15B /* Entity.m */,
 				038D58631B823C180007D15B /* Generated */,
@@ -143,6 +156,8 @@
 				03F4742F1A013506003A7A86 /* WTADataExample */,
 				03F4744C1A013506003A7A86 /* WTADataExampleTests */,
 				03F4742E1A013506003A7A86 /* Products */,
+				036F938F1C5BC59E0021D692 /* WTADataExample-Bridging-Header.h */,
+				036F93901C5BC59E0021D692 /* WTADataExampleTests-Bridging-Header.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -186,6 +201,7 @@
 			children = (
 				03F4744F1A013506003A7A86 /* WTADataExampleTests.m */,
 				039E13181A8CDD8800AD4927 /* WTADataImportTests.m */,
+				036F93971C5BC6B00021D692 /* WTADataSwiftIntegrationTests.swift */,
 				03F4744D1A013506003A7A86 /* Supporting Files */,
 			);
 			path = WTADataExampleTests;
@@ -262,6 +278,7 @@
 		03F474251A013506003A7A86 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "WillowTree, Inc.";
 				TargetAttributes = {
@@ -321,7 +338,9 @@
 			files = (
 				9FB023931A114576009B7C96 /* NSManagedObject+WTAData.m in Sources */,
 				03F474601A013821003A7A86 /* NSManagedObjectContext+WTAData.m in Sources */,
+				036F93931C5BC59F0021D692 /* SwiftEntity+CoreDataProperties.swift in Sources */,
 				03F474361A013506003A7A86 /* AppDelegate.m in Sources */,
+				036F93951C5BC59F0021D692 /* SwiftEntity.swift in Sources */,
 				9FB023921A114576009B7C96 /* NSEntityDescription+WTAData.m in Sources */,
 				038D586F1B823C180007D15B /* _Entity.m in Sources */,
 				03F474331A013506003A7A86 /* main.m in Sources */,
@@ -342,9 +361,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				036F93941C5BC59F0021D692 /* SwiftEntity+CoreDataProperties.swift in Sources */,
 				03F474611A013821003A7A86 /* NSManagedObjectContext+WTAData.m in Sources */,
 				03F4745C1A0135B1003A7A86 /* WTAData.m in Sources */,
 				03F474501A013506003A7A86 /* WTADataExampleTests.m in Sources */,
+				036F93981C5BC6B00021D692 /* WTADataSwiftIntegrationTests.swift in Sources */,
+				036F93961C5BC59F0021D692 /* SwiftEntity.swift in Sources */,
 				039E13191A8CDD8800AD4927 /* WTADataImportTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -460,10 +482,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WTADataExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WTADataExample-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
@@ -471,10 +496,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WTADataExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WTADataExample-Bridging-Header.h";
 			};
 			name = Release;
 		};
@@ -482,6 +509,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -491,6 +519,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WTADataExampleTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/WTADataExample.app/WTADataExample";
 			};
 			name = Debug;
@@ -499,11 +529,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = WTADataExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.willowtreeapps.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WTADataExampleTests-Bridging-Header.h";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/WTADataExample.app/WTADataExample";
 			};
 			name = Release;
@@ -544,9 +576,10 @@
 		03F474371A013506003A7A86 /* WTADataExample.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				036F938E1C5BC42F0021D692 /* WTADataExample 2.xcdatamodel */,
 				03F474381A013506003A7A86 /* WTADataExample.xcdatamodel */,
 			);
-			currentVersion = 03F474381A013506003A7A86 /* WTADataExample.xcdatamodel */;
+			currentVersion = 036F938E1C5BC42F0021D692 /* WTADataExample 2.xcdatamodel */;
 			path = WTADataExample.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/WTADataExample/WTADataExample/Models/SwiftEntity+CoreDataProperties.swift
+++ b/WTADataExample/WTADataExample/Models/SwiftEntity+CoreDataProperties.swift
@@ -1,0 +1,20 @@
+//
+//  SwiftEntity+CoreDataProperties.swift
+//  WTADataExample
+//
+//  Created by Erik LaManna on 1/29/16.
+//  Copyright © 2016 WillowTree, Inc. All rights reserved.
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+import Foundation
+import CoreData
+
+extension SwiftEntity {
+
+    @NSManaged var testString: String?
+    @NSManaged var testInteger: NSNumber?
+
+}

--- a/WTADataExample/WTADataExample/Models/SwiftEntity.swift
+++ b/WTADataExample/WTADataExample/Models/SwiftEntity.swift
@@ -1,0 +1,17 @@
+//
+//  SwiftEntity.swift
+//  WTADataExample
+//
+//  Created by Erik LaManna on 1/29/16.
+//  Copyright © 2016 WillowTree, Inc. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+
+class SwiftEntity: NSManagedObject {
+
+// Insert code here to add functionality to your managed object subclass
+
+}

--- a/WTADataExample/WTADataExample/WTADataExample.xcdatamodeld/.xccurrentversion
+++ b/WTADataExample/WTADataExample/WTADataExample.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>WTADataExample.xcdatamodel</string>
+	<string>WTADataExample 2.xcdatamodel</string>
 </dict>
 </plist>

--- a/WTADataExample/WTADataExample/WTADataExample.xcdatamodeld/WTADataExample 2.xcdatamodel/contents
+++ b/WTADataExample/WTADataExample/WTADataExample.xcdatamodeld/WTADataExample 2.xcdatamodel/contents
@@ -61,9 +61,14 @@
             <entry key="PrimaryAttribute" value="primaryKey"/>
         </userInfo>
     </entity>
+    <entity name="SwiftEntity" representedClassName=".SwiftEntity" syncable="YES">
+        <attribute name="testInteger" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="testString" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
     <elements>
         <element name="Entity" positionX="-63" positionY="-18" width="128" height="105"/>
         <element name="PrimaryKeyEntity" positionX="-63" positionY="9" width="128" height="180"/>
         <element name="RelationshipEntity" positionX="-54" positionY="18" width="128" height="165"/>
+        <element name="SwiftEntity" positionX="-45" positionY="81" width="128" height="75"/>
     </elements>
 </model>

--- a/WTADataExample/WTADataExampleTests-Bridging-Header.h
+++ b/WTADataExample/WTADataExampleTests-Bridging-Header.h
@@ -1,0 +1,9 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "WTAData.h"
+#import "NSEntityDescription+WTAData.h"
+#import "NSManagedObject+WTAData.h"
+#import "NSManagedObjectContext+WTAData.h"
+#import "NSManagedObject+WTADataImport.h"

--- a/WTADataExample/WTADataExampleTests/WTADataSwiftIntegrationTests.swift
+++ b/WTADataExample/WTADataExampleTests/WTADataSwiftIntegrationTests.swift
@@ -1,0 +1,45 @@
+//
+//  WTADataSwiftIntegrationTests.swift
+//  WTADataExample
+//
+//  Created by Erik LaManna on 1/29/16.
+//  Copyright © 2016 WillowTree, Inc. All rights reserved.
+//
+
+import XCTest
+
+class WTADataSwiftIntegrationTests: XCTestCase {
+    
+    var wtaData: WTAData!
+    
+    override func setUp() {
+        super.setUp()
+
+        wtaData = WTAData(inMemoryStackWithModelNamed: "WTADataExample")
+        
+        
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testDeleteAllSwift() {
+        SwiftEntity.createEntityInContext(wtaData.mainContext!)
+        
+        wtaData.mainContext?.saveContext()
+        
+        SwiftEntity.deleteAllInContext(wtaData.mainContext!)
+        
+        do {
+            let items = try SwiftEntity.fetchInContext(wtaData.mainContext!)
+            XCTAssertEqual(items.count, 0, "All entities not deleted")
+        } catch _ {
+            XCTFail("Failed to fetch things")
+        }
+        
+        
+    }
+}


### PR DESCRIPTION
- Swift returns classes with the full module name. This change attempts
  to use the proper last portion of the full module as the entity name.
- Add unit tests and new swift managed object for testing the change.